### PR TITLE
Add a simple HTML-style table for browsing/sorting the datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ New entries can be added to [`data.yml`](./data.yml). Afterwards, run `python re
 
 ## Acknowledgements
 
-This list has greatly benefitted from the survey of [Alva-Manchego et al. (2020)](https://doi.org/10.1162/COLI_a_00370) and [Štajner (2021)](https://doi.org/10.18653/v1/2021.findings-acl.233), as well as notes by [Laura Vásquez-Rodríguez](https://lmvasque.github.io/). Thanks!
+This list has greatly benefitted from the survey of [Alva-Manchego et al. (2020)](https://doi.org/10.1162/COLI_a_00370) and [Štajner (2021)](https://doi.org/10.18653/v1/2021.findings-acl.233), as well as notes by [Laura Vásquez-Rodríguez](https://lmvasque.github.io/). Thanks! Also thanks to [@tollefj](https://github.com/tollefj) for adding the interactive table.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A collection of text simplification datasets with a focus on sentence/paragraph/document-level simplification. All [contributions](#Contributing) are welcome!
 
+For browsing/sorting the datasets, you can use the [interactive table](https://jantrienes.github.io/text-simplification-datasets/).
+
 ## Datasets
 
 Notes on the table columns:

--- a/README.template.md
+++ b/README.template.md
@@ -2,6 +2,8 @@
 
 A collection of text simplification datasets with a focus on sentence/paragraph/document-level simplification. All [contributions](#Contributing) are welcome!
 
+For browsing/sorting the datasets, you can use the [interactive table](https://jantrienes.github.io/text-simplification-datasets/).
+
 ## Datasets
 
 Notes on the table columns:
@@ -18,4 +20,4 @@ New entries can be added to [`data.yml`](./data.yml). Afterwards, run `python re
 
 ## Acknowledgements
 
-This list has greatly benefitted from the survey of [Alva-Manchego et al. (2020)](https://doi.org/10.1162/COLI_a_00370) and [Štajner (2021)](https://doi.org/10.18653/v1/2021.findings-acl.233), as well as notes by [Laura Vásquez-Rodríguez](https://lmvasque.github.io/). Thanks!
+This list has greatly benefitted from the survey of [Alva-Manchego et al. (2020)](https://doi.org/10.1162/COLI_a_00370) and [Štajner (2021)](https://doi.org/10.18653/v1/2021.findings-acl.233), as well as notes by [Laura Vásquez-Rodríguez](https://lmvasque.github.io/). Thanks! Also thanks to [@tollefj](https://github.com/tollefj) for adding the interactive table.

--- a/index.html
+++ b/index.html
@@ -45,15 +45,16 @@
     <table id="data-table">
         <thead>
             <tr>
-                <th onclick="sortData('name')">indName</th>
-                <th onclick="sortData('author')">Author</th>
+                <th onclick="sortData('dataset')">Dataset</th>
+                <th onclick="sortData('author')">Authors</th>
                 <th onclick="sortData('domain')">Domain</th>
                 <th onclick="sortData('instances')">Instances</th>
                 <th onclick="sortData('kind')">Kind</th>
                 <th onclick="sortData('language')">Language</th>
                 <th onclick="sortData('level')">Level</th>
                 <th onclick="sortData('year')">Year</th>
-                <th>References</th>
+                <th>Refs.</th>
+                <th>Link</th>
             </tr>
         </thead>
         <tbody>
@@ -83,6 +84,7 @@
                 'Levels': extractUniqueValues(data, 'level')
             };
             addUnique(uniqueValues);
+            sortData('dataset');
         });
 
         function addUnique(uniqueValues) {
@@ -118,6 +120,7 @@
                     <td>${dataset.level}</td>
                     <td>${dataset.year}</td>
                     <td>${dataset.references}</td>
+                    <td><a href="${dataset.link}" target="_blank">Link</a></td>
                 `;
                 tableBody.appendChild(row);
             }

--- a/index.html
+++ b/index.html
@@ -5,6 +5,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Text Simplification Datasets</title>
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+
+        body {
+            font-family: 'Roboto', sans-serif;
+            background-color: #222;
+            color: #fff;
+        }
+
+        h1 {
+            text-align: center;
+            font-size: 2.5rem;
+        }
+
+        a {
+            color: #fff;
+            /* text-decoration: none; */
+        }
+
         table {
             border-collapse: collapse;
             width: 100%;
@@ -15,7 +33,7 @@
             padding: 8px;
         }
         th {
-            background-color: #f2f2f2;
+            background-color: #333;
             font-weight: bold;
             cursor: pointer;
             min-width: 100px;
@@ -32,10 +50,10 @@
             content: "▼";
         }
         th:hover {
-            background-color: #ddd;
+            background-color: #444;
         }
         tr:nth-child(even) {
-            background-color: #f2f2f2;
+            background-color: #333;
         }
     </style>
 </head>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Data Inspection</title>
+    <style>
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+        th, td {
+            border: 1px solid #dddddd;
+            text-align: left;
+            padding: 8px;
+        }
+        th {
+            background-color: #f2f2f2;
+            font-weight: bold;
+            cursor: pointer;
+            min-width: 100px;
+        }
+        th::after {
+            content: "";
+            display: inline-block;
+            margin-left: 5px;
+        }
+        .asc::after {
+            content: "▲";
+        }
+        .desc::after {
+            content: "▼";
+        }
+        th:hover {
+            background-color: #ddd;
+        }
+        tr:nth-child(even) {
+            background-color: #f2f2f2;
+        }
+    </style>
+</head>
+<body>
+    <h1>Text Simplification Datasets</h1>
+    <h4 id="unique">Details</h4>
+    <table id="data-table">
+        <thead>
+            <tr>
+                <th onclick="sortData('name')">indName</th>
+                <th onclick="sortData('author')">Author</th>
+                <th onclick="sortData('domain')">Domain</th>
+                <th onclick="sortData('instances')">Instances</th>
+                <th onclick="sortData('kind')">Kind</th>
+                <th onclick="sortData('language')">Language</th>
+                <th onclick="sortData('level')">Level</th>
+                <th onclick="sortData('year')">Year</th>
+                <th>References</th>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- Data will be loaded from yml here -->
+        </tbody>
+        </table>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js" integrity="sha512-CSBhVREyzHAjAFfBlIBakjoRUKp5h7VSweP0InR/pAJyptH7peuhCsqAI/snV+TwZmXZqoUklpXp6R6wMnYf5Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script>
+        let currentSortColumn = null;
+        let sortDirection = 'asc';
+
+        async function fetchData() {
+            const response = await fetch('https://raw.githubusercontent.com/jantrienes/text-simplification-datasets/main/data.yml');
+            const data = await response.text();
+            const parsedData = jsyaml.load(data);
+            return parsedData.datasets;
+        }
+
+        const datasets = fetchData().then(data => {
+            populateTable(data);
+
+            const uniqueValues = {
+                'Domains': extractUniqueValues(data, 'domain'),
+                'Kinds': extractUniqueValues(data, 'kind'),
+                'Languages': extractUniqueValues(data, 'language'),
+                'Levels': extractUniqueValues(data, 'level')
+            };
+            addUnique(uniqueValues);
+        });
+
+        function addUnique(uniqueValues) {
+            const topInfoElement = document.querySelector('#unique');
+            let innerHTML = '';
+            for (const [key, values] of Object.entries(uniqueValues)) {
+                innerHTML += `<li><strong>${key}:</strong> <code>${values.join(', ')}</code></li>`;
+            }
+            topInfoElement.innerHTML = `<ul>${innerHTML}</ul>`;
+        }
+
+        function extractUniqueValues(datasets, field) {
+            const uniqueValues = new Set();
+            for (const key in datasets) {
+                uniqueValues.add(datasets[key][field]);
+            }
+            return Array.from(uniqueValues).filter(value => value !== null && value !== undefined);
+        }
+
+        async function populateTable(datasets) {
+            const tableBody = document.querySelector('#data-table tbody');
+            tableBody.innerHTML = '';
+            for (const key in datasets) {
+                const dataset = datasets[key];
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${dataset.name}</td>
+                    <td>${dataset.author}</td>
+                    <td>${dataset.domain}</td>
+                    <td>${dataset.instances}</td>
+                    <td>${dataset.kind}</td>
+                    <td>${dataset.language}</td>
+                    <td>${dataset.level}</td>
+                    <td>${dataset.year}</td>
+                    <td>${dataset.references}</td>
+                `;
+                tableBody.appendChild(row);
+            }
+        }
+
+        function sortData(column) {
+            const thead = document.querySelector('#data-table thead');
+            const ths = Array.from(thead.querySelectorAll('th'));
+            const tbody = document.querySelector('#data-table tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+
+            if (currentSortColumn === column) {
+                sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+            } else {
+                sortDirection = 'asc';
+            }
+
+            const index = ths.findIndex(th => th.textContent.toLowerCase() === column.toLowerCase());
+
+            ths.forEach(th => {
+                th.classList.remove('asc', 'desc');
+            });
+            ths[index].classList.add(sortDirection);
+            rows.sort((a, b) => {
+                const aValue = a.querySelectorAll('td')[index].textContent.trim();
+                const bValue = b.querySelectorAll('td')[index].textContent.trim();
+
+                if (aValue === bValue) {
+                    return 0;
+                }
+
+                return sortDirection === 'asc' ? (aValue > bValue ? 1 : -1) : (aValue < bValue ? 1 : -1);
+            });
+
+            while (tbody.firstChild) {
+                tbody.removeChild(tbody.firstChild);
+            }
+
+            rows.forEach(row => tbody.appendChild(row));
+            currentSortColumn = column;
+        }
+
+    </script>
+    
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Data Inspection</title>
+    <title>Text Simplification Datasets</title>
     <style>
         table {
             border-collapse: collapse;


### PR DESCRIPTION
Hey! I recently found this resource (which is fantastic!), but I found it a bit cumbersome to look through the data. I added an `index.html` to support hosting with GH pages. I added the URL in the suggested update to the README, but please take a second look. The links will not be active until you enable _pages_ in the settings.

See the temporarily hosted version here: <https://tollefj.github.io/text-simplification-datasets/>

![image](https://github.com/jantrienes/text-simplification-datasets/assets/5024871/57d69f1e-4ea5-4f8b-9ebf-d4e688e47a6a)
